### PR TITLE
Fixes to setup file for proper installation with pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+scipy
+requests

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,23 @@
+from glob import glob
+from os.path import basename
+from os.path import splitext
+
 from setuptools import setup
+from setuptools import find_packages
 
 setup(
-    name='Athena',
+    name='athena',
     version='0.5',
-    packages=['athena.athena'],
+    packages=find_packages('code'),
+    package_dir={'': 'code'},    
+    py_modules=[splitext(basename(path))[0] for path in glob('code/athena/*.py')],
     url='',
     license='',
     author='Filip Zagorski',
     author_email='',
-    description=''
+    description='',
+    install_requires=[
+        'requests',
+        'scipy',
+        ]
 )


### PR DESCRIPTION
# Setup Changes

The setup file now installs the `code/` directory as the `athena` package and all python files under `code/athena/` as modules of that package. It also ensures the required packages (those imported by files within `code/athena/` are installed as well.

## Option to include CLI
Currently, the `code/athena.py` file is not included as a package module since it is a command-line script and should not be imported into a piece of python code. 

Moving the `athena.py` file into a `__main__.py` file under `code/athena/` would allow for it to be called as a command instead of a script like so: `python3 -m athena [remaining parameters...]` and could help reduce some of the file/directory naming confusion. Then, once someone installs athena with pip (either from Github of PyPI) they could both use the athena modules and the athena command-line tool, without actually needing to clone the repo. 
